### PR TITLE
optimization the message type define

### DIFF
--- a/include/qrb_ros_benchmark/qrb_message_types.hpp
+++ b/include/qrb_ros_benchmark/qrb_message_types.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+#ifndef QRB_ROS_BENCHMARK__QRB_MESSAGE_TYPES_HPP_
+#define QRB_ROS_BENCHMARK__QRB_MESSAGE_TYPES_HPP_
+
+// Standard library
+#include <string>
+#include <vector>
+
+// QRB ROS transport types
+#include "qrb_ros_transport_image_type/image.hpp"
+#include "qrb_ros_transport_imu_type/imu.hpp"
+#include "qrb_ros_transport_point_cloud2_type/point_cloud2.hpp"
+
+// DMABUF transport types
+#include "dmabuf_transport/type/image.hpp"
+#include "dmabuf_transport/type/point_cloud2.hpp"
+
+// ROS message types
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/compressed_image.hpp"
+#include "qrb_ros_tensor_list_msgs/msg/tensor_list.hpp"
+
+namespace qrb_ros
+{
+namespace benchmark
+{
+
+// Common macro for creating ROS message subscriber
+#define FOR_EACH_ROS_MESSAGE_TYPE(MACRO) \
+  MACRO(sensor_msgs::msg::Image) \
+  MACRO(sensor_msgs::msg::CompressedImage) \
+  MACRO(qrb_ros_tensor_list_msgs::msg::TensorList)
+
+// Common macro for creating QRB transport type subscriber/publisher
+#define FOR_EACH_QRB_TRANSPORT_TYPE(MACRO) \
+  MACRO("qrb_ros/transport/type/Image", qrb_ros::transport::type::Image) \
+  MACRO("qrb_ros/transport/type/Imu", qrb_ros::transport::type::Imu)
+
+// Common macro for creating dmabuf transport type subscriber/publisher
+#define FOR_EACH_DMABUF_TRANSPORT_TYPE(MACRO) \
+  MACRO("dmabuf_transport/type/Image", dmabuf_transport::type::Image) \
+  MACRO("dmabuf_transport/type/PointCloud2", dmabuf_transport::type::PointCloud2)
+
+}  // namespace benchmark
+}  // namespace qrb_ros
+
+#endif  // QRB_ROS_BENCHMARK__QRB_MESSAGE_TYPES_HPP_

--- a/include/qrb_ros_benchmark/qrb_monitor_node.hpp
+++ b/include/qrb_ros_benchmark/qrb_monitor_node.hpp
@@ -4,18 +4,15 @@
 #ifndef QRB_ROS_BENCHMARK__QRB_MONITOR_NODE_HPP_
 #define QRB_ROS_BENCHMARK__QRB_MONITOR_NODE_HPP_
 
+// Standard library
 #include <string>
 
+// ROS libraries
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_benchmark/monitor_node.hpp"
-#include "qrb_ros_transport_image_type/image.hpp"
-#include "qrb_ros_transport_imu_type/imu.hpp"
-#include "qrb_ros_transport_point_cloud2_type/point_cloud2.hpp"
-#include "dmabuf_transport/type/image.hpp"
-#include "dmabuf_transport/type/point_cloud2.hpp"
-#include "sensor_msgs/msg/image.hpp"
-#include "sensor_msgs/msg/compressed_image.hpp"
-#include "qrb_ros_tensor_list_msgs/msg/tensor_list.hpp"
+
+// QRB message types (includes all necessary message type headers)
+#include "qrb_ros_benchmark/qrb_message_types.hpp"
 
 namespace qrb_ros
 {
@@ -25,12 +22,10 @@ namespace benchmark
 class QrbMonitorNode : public ros2_benchmark::MonitorNode
 {
 public:
-
   // QrbMonitorNode constructor.
   explicit QrbMonitorNode(const rclcpp::NodeOptions &);
 
 private:
-
   // Determine the format, request to create the corresponding type of subscriber.
   void create_monitor_subscriber();
 

--- a/include/qrb_ros_benchmark/qrb_playback_node.hpp
+++ b/include/qrb_ros_benchmark/qrb_playback_node.hpp
@@ -4,20 +4,17 @@
 #ifndef QRB_ROS_BENCHMARK__QRB_PLAYBACK_NODE_HPP_
 #define QRB_ROS_BENCHMARK__QRB_PLAYBACK_NODE_HPP_
 
+// Standard library
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+// ROS libraries
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_benchmark/playback_node.hpp"
-#include "qrb_ros_transport_image_type/image.hpp"
-#include "qrb_ros_transport_imu_type/imu.hpp"
-#include "qrb_ros_transport_point_cloud2_type/point_cloud2.hpp"
-#include "dmabuf_transport/type/image.hpp"
-#include "dmabuf_transport/type/point_cloud2.hpp"
-#include "sensor_msgs/msg/image.hpp"
-#include "sensor_msgs/msg/compressed_image.hpp"
-#include "qrb_ros_tensor_list_msgs/msg/tensor_list.hpp"
+
+// QRB message types (includes all necessary message type headers)
+#include "qrb_ros_benchmark/qrb_message_types.hpp"
 
 namespace qrb_ros
 {
@@ -51,12 +48,10 @@ public:
 class QrbPlaybackNode : public ros2_benchmark::PlaybackNode
 {
 public:
-
   // QrbPlaybackNode constructor.
   explicit QrbPlaybackNode(const rclcpp::NodeOptions &);
 
 private:
-
   // Check if the messages buffer is full for request size.
   bool AreBuffersFull() const override;
 
@@ -78,7 +73,6 @@ private:
 
   // Return publishers count number.
   size_t GetPublisherCount() const override;
-
 
   // Determine the format, request to create the corresponding type of pub and sub.
   void create_playback_pubsub(const size_t index, const std::string format);


### PR DESCRIPTION
This pull request introduces a refactor to streamline the handling of message types in the QRB ROS benchmark project. The changes consolidate message type definitions into a single header file and replace repetitive code with macros for creating subscribers, publishers, and message handlers. This improves maintainability and reduces redundancy across the codebase.

### Refactoring for Message Type Handling

* **Centralized Message Type Definitions**:
  - Added a new header file `qrb_message_types.hpp` to consolidate all message type includes and macros for QRB transport types, DMABUF transport types, and ROS message types. This simplifies code organization and ensures all necessary headers are included in one place.

* **Replaced Repetitive Code with Macros**:
  - Refactored the `create_monitor_subscriber` method in `qrb_monitor_node.cpp` to use macros (`FOR_EACH_QRB_TRANSPORT_TYPE`, `FOR_EACH_DMABUF_TRANSPORT_TYPE`, and `FOR_EACH_ROS_MESSAGE_TYPE`) for creating transport type and ROS message subscribers. This eliminates the need for repeated `if-else` blocks.
  - Similarly, refactored the `create_playback_pubsub` and `PublishMessage` methods in `qrb_playback_node.cpp` to use macros for creating publishers and handling message publishing. [[1]](diffhunk://#diff-6c81c5634488a36c22dd6f685ece7e454066b3e7c6aa0deafc88bd4c2407fb9dL55-R80) [[2]](diffhunk://#diff-6c81c5634488a36c22dd6f685ece7e454066b3e7c6aa0deafc88bd4c2407fb9dL263-R283)

### Codebase Simplification

* **Header File Cleanup**:
  - Removed redundant includes from `qrb_monitor_node.hpp` and `qrb_playback_node.hpp` by replacing them with a single include of `qrb_message_types.hpp`. This reduces clutter and ensures consistency in included headers. [[1]](diffhunk://#diff-7f9a32fe378b57d8421964548a73f5ab5ab4dbb113fb8a885ebce75a7a044ccaR7-R15) [[2]](diffhunk://#diff-3b37989260b1bad4d8d0316ada7cde825f0fde4776be1ed7a16f5e0118c2a55eR7-R17)

